### PR TITLE
Update IsIterableWithSize.hx

### DIFF
--- a/src/org/hamcrest/collection/IsIterableWithSize.hx
+++ b/src/org/hamcrest/collection/IsIterableWithSize.hx
@@ -24,7 +24,7 @@ class IsIterableWithSize<E> extends FeatureMatcher<Iterable<E>, Int>
     {
         if (Std.is(actual, Array))
         {
-            return cast(actual).length;
+            return cast(actual, Array<Dynamic>).length;
         }
 	    else
         {


### PR DESCRIPTION
This was causing the compilation error ```Iterable<org.hamcrest.collection.IsIterableWithSize.E> has no field length```
tested on js target with haxe 3.2.0