### PR TITLE
Use safe cast properly. Fixed haxe 3.2 compilation error.

### DIFF
--- a/src/org/hamcrest/collection/IsIterableWithSize.hx
+++ b/src/org/hamcrest/collection/IsIterableWithSize.hx
@@ -22,16 +22,13 @@ class IsIterableWithSize<E> extends FeatureMatcher<Iterable<E>, Int>
 
     override function featureValueOf(actual:Iterable<E>):Int
     {
-        if (Std.is(actual, Array))
-        {
-            return cast(actual).length;
-        }
-	    else
-        {
-			var size = 0;
-			for (value in actual)
-				size++;
-			return size;
+        try {
+            return cast(actual, Array<Dynamic>).length;
+        } catch(e:Dynamic) {
+            var size = 0;
+            for (value in actual)
+                size++;
+            return size;
         }
     }
     


### PR DESCRIPTION
Fixed the same issue as #3, but this change removed the use of `Std.is`.

I hope this can be merged, and a fix can be released to haxelib soon. It is because haxe 3.2 was released 6+ months ago... ;)