### PR TITLE
Fixed deprecated IMap interface

### DIFF
--- a/src/org/hamcrest/collection/IsHashContaining.hx
+++ b/src/org/hamcrest/collection/IsHashContaining.hx
@@ -4,6 +4,7 @@
 
 package org.hamcrest.collection;
 
+import haxe.Constraints.IMap;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeMatcher;
@@ -33,7 +34,7 @@ class IsHashContaining<K, V> extends TypeSafeMatcher<Map<K, V>>
     
     override function isExpectedType(value:Dynamic):Bool
     {
-    	return Std.is(value, Map.IMap);
+    	return Std.is(value, IMap);
     }
 
     override function describeMismatchSafely(hash:Map<K, V>, mismatchDescription:Description)

--- a/src/org/hamcrest/collection/IsIterableWithSize.hx
+++ b/src/org/hamcrest/collection/IsIterableWithSize.hx
@@ -24,7 +24,7 @@ class IsIterableWithSize<E> extends FeatureMatcher<Iterable<E>, Int>
     {
         if (Std.is(actual, Array))
         {
-            return cast(actual).length;
+            return cast(actual,Array<Dynamic>).length;
         }
 	    else
         {


### PR DESCRIPTION
Just a tiny fix to erase deprecated warning all the time
