### PR TITLE
Use Std.isOfType instead Std.is

### DIFF
--- a/src/org/hamcrest/BaseDescription.hx
+++ b/src/org/hamcrest/BaseDescription.hx
@@ -35,7 +35,7 @@ class BaseDescription implements Description
         {
             append("null");
         }
-        else if (Std.is(value, String))
+        else if (Std.isOfType(value, String))
         {
             escapeAndAppend(cast(value, String));
         }

--- a/src/org/hamcrest/MatcherAssert.hx
+++ b/src/org/hamcrest/MatcherAssert.hx
@@ -37,7 +37,7 @@ class MatcherAssert
 				throw new AssertionException(description.toString(), null, info);
 			}
 		}
-		else if (Std.is(actual, Bool))
+		else if (Std.isOfType(actual, Bool))
 		{
 			if (!actual)
 			{
@@ -53,19 +53,19 @@ class MatcherAssert
 	
 //	public static function assertThat2<T>(valueOne:Dynamic, ?valueTwo:Dynamic, ?matcher:Matcher<T>, ?info:PosInfos)
 //	{
-//		if (Std.is(valueOne, String) && matcher != null)
+//		if (Std.isOfType(valueOne, String) && matcher != null)
 //		{
 //			assertThatMatch(valueOne, valueTwo, matcher, info);
 //		}
-//		else if (/*Std.is(valueOne, T) &&*/ Std.is(valueTwo, Matcher) && matcher == null)
+//		else if (/*Std.isOfType(valueOne, T) &&*/ Std.isOfType(valueTwo, Matcher) && matcher == null)
 //		{
 //			assertThatMatch("", valueOne, valueTwo, info);
 //		}
-//		else if (Std.is(valueOne, String) && Std.is(valueTwo, Bool) && matcher == null)
+//		else if (Std.isOfType(valueOne, String) && Std.isOfType(valueTwo, Bool) && matcher == null)
 //		{
 //			assertThatBool(valueOne, valueTwo, info);
 //		}
-//		else if (Std.is(valueOne, Bool) && valueTwo == null && matcher == null)
+//		else if (Std.isOfType(valueOne, Bool) && valueTwo == null && matcher == null)
 //		{
 //			assertThatBool("", valueOne, info);
 //		}

--- a/src/org/hamcrest/collection/IsArray.hx
+++ b/src/org/hamcrest/collection/IsArray.hx
@@ -38,7 +38,7 @@ class IsArray<T> extends TypeSafeMatcher<Array<T>>
 	
 	override function isExpectedType(value:Dynamic):Bool
 	{
-		return Std.is(value, Array);
+		return Std.isOfType(value, Array);
 	}
 
 	override function describeMismatchSafely(actual:Array<T>, mismatchDescription:Description):Void

--- a/src/org/hamcrest/collection/IsArrayContaining.hx
+++ b/src/org/hamcrest/collection/IsArrayContaining.hx
@@ -33,7 +33,7 @@ class IsArrayContaining<T> extends TypeSafeMatcher<Array<T>>
     
     override function isExpectedType(value:Dynamic):Bool
     {
-    	return Std.is(value, Array);
+    	return Std.isOfType(value, Array);
     }
 
     override function describeMismatchSafely(item:Array<T>, mismatchDescription:Description):Void
@@ -53,7 +53,7 @@ class IsArrayContaining<T> extends TypeSafeMatcher<Array<T>>
      */
     public static function hasItemInArray<T>(element:Dynamic):Matcher<Array<T>>
     {
-    	if (Std.is(element, Matcher))
+    	if (Std.isOfType(element, Matcher))
 	        return new IsArrayContaining<T>(element);
 	    
 	    return hasItemInArray(IsEqual.equalTo(element));

--- a/src/org/hamcrest/collection/IsArrayContainingInAnyOrder.hx
+++ b/src/org/hamcrest/collection/IsArrayContainingInAnyOrder.hx
@@ -28,7 +28,7 @@ class IsArrayContainingInAnyOrder<T> extends TypeSafeMatcher<Array<T>>
     
     override function isExpectedType(value:Dynamic):Bool
     {
-    	return Std.is(value, Array);
+    	return Std.isOfType(value, Array);
     }
     
     override function describeMismatchSafely(item:Array<T>, mismatchDescription:Description)

--- a/src/org/hamcrest/collection/IsArrayContainingInOrder.hx
+++ b/src/org/hamcrest/collection/IsArrayContainingInOrder.hx
@@ -28,7 +28,7 @@ class IsArrayContainingInOrder<E> extends TypeSafeMatcher<Array<E>>
     
     override function isExpectedType(value:Dynamic):Bool
     {
-    	return Std.is(value, Array);
+    	return Std.isOfType(value, Array);
     }
     
     override function describeMismatchSafely(item:Array<E>, mismatchDescription:Description)

--- a/src/org/hamcrest/collection/IsHashContaining.hx
+++ b/src/org/hamcrest/collection/IsHashContaining.hx
@@ -34,7 +34,7 @@ class IsHashContaining<K, V> extends TypeSafeMatcher<Map<K, V>>
     
     override function isExpectedType(value:Dynamic):Bool
     {
-    	return Std.is(value, IMap);
+    	return Std.isOfType(value, IMap);
     }
 
     override function describeMismatchSafely(hash:Map<K, V>, mismatchDescription:Description)
@@ -90,7 +90,7 @@ class IsHashContaining<K, V> extends TypeSafeMatcher<Map<K, V>>
     
     static function getMatcher<T>(value:Dynamic):Matcher<T>
     {    	
-    	return Std.is(value, Matcher) ? value : IsEqual.equalTo(value);
+    	return Std.isOfType(value, Matcher) ? value : IsEqual.equalTo(value);
     }
 }
 

--- a/src/org/hamcrest/collection/IsIterableWithSize.hx
+++ b/src/org/hamcrest/collection/IsIterableWithSize.hx
@@ -22,7 +22,7 @@ class IsIterableWithSize<E> extends FeatureMatcher<Iterable<E>, Int>
 
     override function featureValueOf(actual:Iterable<E>):Int
     {
-        if (Std.is(actual, Array))
+        if (Std.isOfType(actual, Array))
         {
             return cast(actual, Array<Dynamic>).length;
         }
@@ -50,7 +50,7 @@ class IsIterableWithSize<E> extends FeatureMatcher<Iterable<E>, Int>
 	{
 		featureName = FEATURE_NAME;
 		featureDescription = FEATURE_DESCRIPTION;
-		if (Std.is(actual, Array))
+		if (Std.isOfType(actual, Array))
 		{
 			featureName = featureName.split("iterable").join("array");
 			featureDescription =featureDescription.split("iterable").join("array");
@@ -67,9 +67,9 @@ class IsIterableWithSize<E> extends FeatureMatcher<Iterable<E>, Int>
      */
     public static function hasSize<T>(value:Dynamic):Matcher<Iterable<T>>
     {
-    	if (Std.is(value, Matcher))
+    	if (Std.isOfType(value, Matcher))
     		return new IsIterableWithSize<T>(value);
-    	else if (Std.is(value, Int))
+    	else if (Std.isOfType(value, Int))
     		return hasSize(IsEqual.equalTo(value));
     	
     	throw new IllegalArgumentException();

--- a/src/org/hamcrest/core/AllOf.hx
+++ b/src/org/hamcrest/core/AllOf.hx
@@ -55,11 +55,11 @@ class AllOf<T> extends DiagnosingMatcher<T>
     							 ?tenth:Matcher<T>):AllOf<T>
     {
     	var matchers:Array<Matcher<T>>;
-    	if (Std.is(first, Array))
+    	if (Std.isOfType(first, Array))
     	{
     		matchers = cast first;
     	}
-    	else if (Std.is(first, Matcher))
+    	else if (Std.isOfType(first, Matcher))
     	{
     		matchers = [];
     		matchers.push(cast first);

--- a/src/org/hamcrest/core/AnyOf.hx
+++ b/src/org/hamcrest/core/AnyOf.hx
@@ -38,11 +38,11 @@ class AnyOf<T> extends ShortcutCombination<T>
     {
     
     	var matchers:Array<Matcher<T>>;
-    	if (Std.is(first, Array))
+    	if (Std.isOfType(first, Array))
     	{
     		matchers = cast first;
     	}
-    	else if (Std.is(first, Matcher))
+    	else if (Std.isOfType(first, Matcher))
     	{
     		matchers = [];
     		matchers.push(cast first);

--- a/src/org/hamcrest/core/Is.hx
+++ b/src/org/hamcrest/core/Is.hx
@@ -43,10 +43,10 @@ class Is<T> extends BaseMatcher<T>
 
 	public static function is<T>(value:Dynamic):Matcher<T>
 	{
-		if (Std.is(value, Matcher))
+		if (Std.isOfType(value, Matcher))
 			return new Is<T>(value);
 
-		if (Std.is(value, Class))
+		if (Std.isOfType(value, Class))
 			return isA(value);
 
 		return is(IsEqual.equalTo(value));

--- a/src/org/hamcrest/core/IsCollectionContaining.hx
+++ b/src/org/hamcrest/core/IsCollectionContaining.hx
@@ -53,7 +53,7 @@ class IsCollectionContaining<T> extends TypeSafeDiagnosingMatcher<Iterable<T>>
     
     public static function hasItem<T>(value:Dynamic):Matcher<Iterable<T>>
     {
-    	if (Std.is(value, Matcher))
+    	if (Std.isOfType(value, Matcher))
     		return new IsCollectionContaining<T>(value);
     	
     	return new IsCollectionContaining<T>(IsEqual.equalTo(value));
@@ -67,7 +67,7 @@ class IsCollectionContaining<T> extends TypeSafeDiagnosingMatcher<Iterable<T>>
     		
     		if (values.length > 0)
 	    	{
-	    		if (Std.is(values[0], Matcher))
+	    		if (Std.isOfType(values[0], Matcher))
 	    		{
 					
 				    for (elementMatcher in values)

--- a/src/org/hamcrest/core/IsEqual.hx
+++ b/src/org/hamcrest/core/IsEqual.hx
@@ -89,7 +89,7 @@ class IsEqual<T> extends BaseMatcher<T>
 
     static function isArray(value:Dynamic):Bool
     {
-        return Std.is(value, Array);
+        return Std.isOfType(value, Array);
     }
 
     static function isEnum(value: Dynamic):Bool

--- a/src/org/hamcrest/core/IsInstanceOf.hx
+++ b/src/org/hamcrest/core/IsInstanceOf.hx
@@ -39,7 +39,7 @@ class IsInstanceOf extends DiagnosingMatcher<Dynamic>
 			return false;
 		}
       
-		if (!Std.is(item, expectedClass))
+		if (!Std.isOfType(item, expectedClass))
 		{
 			var type = Type.getClass(item);
 			var className = type != null ? Type.getClassName(type) : "Dynamic";

--- a/src/org/hamcrest/core/IsNot.hx
+++ b/src/org/hamcrest/core/IsNot.hx
@@ -42,7 +42,7 @@ class IsNot<T> extends BaseMatcher<T>
      */
     public static function not<T>(value:Dynamic):Matcher<T>
     {
-    	if (Std.is(value, Matcher))
+    	if (Std.isOfType(value, Matcher))
     		return new IsNot<T>(value);
     	
     	return not(IsEqual.equalTo(value));

--- a/src/org/hamcrest/core/ShortcutCombination.hx
+++ b/src/org/hamcrest/core/ShortcutCombination.hx
@@ -12,13 +12,13 @@ import org.hamcrest.Exception;
 class ShortcutCombination<T> extends BaseMatcher<T>
 {
     var matchers:Iterable<Matcher<T>>;
-    var operator:String;
+    var _operator:String;
 	
-    private function new(matchers:Iterable<Matcher<T>>, operator:String)
+    private function new(matchers:Iterable<Matcher<T>>, _operator:String)
     {
     	super();
         this.matchers = matchers;
-        this.operator = operator;
+        this._operator = _operator;
     }
     
     function doesMatch(value:Dynamic, shortcut:Bool):Bool 
@@ -33,6 +33,6 @@ class ShortcutCombination<T> extends BaseMatcher<T>
     
     override public function describeTo(description:Description):Void
     {
-        description.appendList("(", " " + operator + " ", ")", matchers);
+        description.appendList("(", " " + _operator + " ", ")", matchers);
     }
 }

--- a/src/org/hamcrest/core/SubstringMatcher.hx
+++ b/src/org/hamcrest/core/SubstringMatcher.hx
@@ -38,7 +38,7 @@ class SubstringMatcher extends TypeSafeMatcher<String>
     
     override function isExpectedType(value:Dynamic):Bool
     {
-    	return Std.is(value, String);    
+    	return Std.isOfType(value, String);    
     }
 
     function evalSubstringOf(string:String):Bool

--- a/src/org/hamcrest/internal/TypeIdentifier.hx
+++ b/src/org/hamcrest/internal/TypeIdentifier.hx
@@ -15,7 +15,7 @@ class TypeIdentifier
 		if (value == null)
 			return false;
 			
-		if (Std.is(value, Array))
+		if (Std.isOfType(value, Array))
 			return true;
 
 		var field = Reflect.field(value, "iterator");
@@ -43,7 +43,7 @@ class TypeIdentifier
 	
 	public static function isComparablePrimitive(value:Dynamic):Bool
 	{
-		return (isNumber(value) || Std.is(value, String));
+		return (isNumber(value) || Std.isOfType(value, String));
 	}
 	
 	public static function hasCompareToFunction(value:Dynamic):Bool
@@ -60,7 +60,7 @@ class TypeIdentifier
 		if (isComparablePrimitive(value))
 			return true;
 		
-		if (Std.is(value, Date)) // assumes we'll be comparing date.getTime()
+		if (Std.isOfType(value, Date)) // assumes we'll be comparing date.getTime()
 			return true;
 		
 		if (hasCompareToFunction(value))

--- a/src/org/hamcrest/internal/VarArgMatchers.hx
+++ b/src/org/hamcrest/internal/VarArgMatchers.hx
@@ -44,7 +44,7 @@ class VarArgMatchers
 	                                 ?tenth:Dynamic):Array<Matcher<T>>
     {
     	var matchers:Array<Matcher<T>> = [];
-    	if (Std.is(first, Array))
+    	if (Std.isOfType(first, Array))
     	{
     		var items:Array<Dynamic> = cast first;
 			for (item in items) matchers.push(getMatcher(item));
@@ -69,7 +69,7 @@ class VarArgMatchers
 
 	static function getMatcher<T>(item:Dynamic):Matcher<T>
 	{
-		if (Std.is(item, Matcher))
+		if (Std.isOfType(item, Matcher))
 			return cast item;
 		else
 			return IsEqual.equalTo(item);

--- a/src/org/hamcrest/number/IsCloseTo.hx
+++ b/src/org/hamcrest/number/IsCloseTo.hx
@@ -32,7 +32,7 @@ class IsCloseTo extends TypeSafeMatcher<Float>
 
     override function isExpectedType(value:Dynamic):Bool
     {
-    	return Std.is(value, Float);   
+    	return Std.isOfType(value, Float);   
     }
     
     override function describeMismatchSafely(item:Float, mismatchDescription:Description)

--- a/src/org/hamcrest/number/OrderingComparison.hx
+++ b/src/org/hamcrest/number/OrderingComparison.hx
@@ -50,7 +50,7 @@ class OrderingComparison extends TypeSafeMatcher<Dynamic>
 			{
 				value = Reflect.compare(actual, expected);
 			}
-			else if (TypeIdentifier.isNumber(actual) && Std.is(expected, Date))
+			else if (TypeIdentifier.isNumber(actual) && Std.isOfType(expected, Date))
 			{
 				value = Reflect.compare(actual, cast(expected, Date).getTime());
 			}
@@ -65,13 +65,13 @@ class OrderingComparison extends TypeSafeMatcher<Dynamic>
 				throw new IllegalArgumentException("Expected value is not of a comparable type. [" + expected + "]");
 			}
 		}
-		else if (Std.is(actual, Date))
+		else if (Std.isOfType(actual, Date))
 		{
 			if (TypeIdentifier.isNumber(expected))
 			{
 				value = Reflect.compare(cast(actual, Date).getTime(), expected);
 			}
-			else if (Std.is(expected, Date))
+			else if (Std.isOfType(expected, Date))
 			{
 				value = Reflect.compare(cast(actual, Date).getTime(), cast(expected, Date).getTime());
 			}

--- a/test/org/hamcrest/CustomMatcherTest.hx
+++ b/test/org/hamcrest/CustomMatcherTest.hx
@@ -21,6 +21,6 @@ private class SomeCustomMatcher<T> extends CustomMatcher<T>
 	
     override public function matches(item:Dynamic):Bool
     {
-        return Std.is(item, String);
+        return Std.isOfType(item, String);
     }
 }

--- a/test/org/hamcrest/CustomTypeSafeMatcherTest.hx
+++ b/test/org/hamcrest/CustomTypeSafeMatcherTest.hx
@@ -48,6 +48,6 @@ private class SomeCustomTypeSafeMatcher<T> extends CustomTypeSafeMatcher<T>
     
     override function isExpectedType(type:Dynamic):Bool
     {
-    	return Std.is(type, String);    
+    	return Std.isOfType(type, String);    
     }
 }

--- a/test/org/hamcrest/TypeSafeMatcherTest.hx
+++ b/test/org/hamcrest/TypeSafeMatcherTest.hx
@@ -59,7 +59,7 @@ class TypeSafeMatcherSubclass extends TypeSafeMatcher<String>
     
     override function isExpectedType(type:Dynamic):Bool
     {
-    	return Std.is(type, String);    
+    	return Std.isOfType(type, String);    
     }
 }
 

--- a/test/org/hamcrest/collection/IsIterableContainingInOrderTest.hx
+++ b/test/org/hamcrest/collection/IsIterableContainingInOrderTest.hx
@@ -100,6 +100,6 @@ class WithValueFeatureMatcher<U> extends FeatureMatcher<WithValue, U>
     
     override function isExpectedType(value:Dynamic):Bool
     {
-    	return Std.is(value, WithValue);
+    	return Std.isOfType(value, WithValue);
     }
 }

--- a/test/org/hamcrest/core/SampleBaseClass.hx
+++ b/test/org/hamcrest/core/SampleBaseClass.hx
@@ -16,6 +16,6 @@ class SampleBaseClass
 
     public function equals(obj:Dynamic):Bool
     {
-        return Std.is(obj, SampleBaseClass) && value == cast(obj, SampleBaseClass).value;
+        return Std.isOfType(obj, SampleBaseClass) && value == cast(obj, SampleBaseClass).value;
     }
 }

--- a/test/org/hamcrest/number/OrderingComparisonTest.hx
+++ b/test/org/hamcrest/number/OrderingComparisonTest.hx
@@ -133,11 +133,11 @@ private class ComparatorEg
 	public function compareTo(data:Dynamic):Int
 	{
 		var expected:Float = -1;
-		if (Std.is(data, ComparatorEg))
+		if (Std.isOfType(data, ComparatorEg))
 			expected = data.value;
-		else if (Std.is(data, Int) || Std.is(data, Float))
+		else if (Std.isOfType(data, Int) || Std.isOfType(data, Float))
 			expected = data;
-		else if (Std.is(data, Date))
+		else if (Std.isOfType(data, Date))
 			expected = cast(data, Date).getTime();
 		
 		return Reflect.compare(value, expected);


### PR DESCRIPTION
This PR switches Hamcrest lib to use Std.isOfType instead Std.is which has been decrepated. Avoids a lot of warnings in the console. 

Don't know if this will brake backwards compatibility with Haxe 3 and I don't know if Haxe 3 support is worth pursuing. 