### PR TITLE
Fix Std.is deprecation warnings

### DIFF
--- a/src/org/hamcrest/BaseDescription.hx
+++ b/src/org/hamcrest/BaseDescription.hx
@@ -7,6 +7,12 @@ package org.hamcrest;
 import org.hamcrest.internal.SelfDescribingValueIterator;
 import org.hamcrest.Exception;
 
+#if (haxe_ver >= 4.2)
+import Std.isOfType;
+#else
+import Std.is as isOfType;
+#end
+
 using org.hamcrest.internal.TypeIdentifier;
 
 /**
@@ -35,7 +41,7 @@ class BaseDescription implements Description
         {
             append("null");
         }
-        else if (Std.is(value, String))
+        else if (isOfType(value, String))
         {
             escapeAndAppend(cast(value, String));
         }

--- a/src/org/hamcrest/MatcherAssert.hx
+++ b/src/org/hamcrest/MatcherAssert.hx
@@ -7,6 +7,12 @@ package org.hamcrest;
 import org.hamcrest.Exception;
 import haxe.PosInfos;
 
+#if (haxe_ver >= 4.2)
+import Std.isOfType;
+#else
+import Std.is as isOfType;
+#end
+
 class MatcherAssert
 {
 	private function new()
@@ -37,7 +43,7 @@ class MatcherAssert
 				throw new AssertionException(description.toString(), null, info);
 			}
 		}
-		else if (Std.is(actual, Bool))
+		else if (isOfType(actual, Bool))
 		{
 			if (!actual)
 			{
@@ -53,19 +59,19 @@ class MatcherAssert
 	
 //	public static function assertThat2<T>(valueOne:Dynamic, ?valueTwo:Dynamic, ?matcher:Matcher<T>, ?info:PosInfos)
 //	{
-//		if (Std.is(valueOne, String) && matcher != null)
+//		if (isOfType(valueOne, String) && matcher != null)
 //		{
 //			assertThatMatch(valueOne, valueTwo, matcher, info);
 //		}
-//		else if (/*Std.is(valueOne, T) &&*/ Std.is(valueTwo, Matcher) && matcher == null)
+//		else if (/*isOfType(valueOne, T) &&*/ isOfType(valueTwo, Matcher) && matcher == null)
 //		{
 //			assertThatMatch("", valueOne, valueTwo, info);
 //		}
-//		else if (Std.is(valueOne, String) && Std.is(valueTwo, Bool) && matcher == null)
+//		else if (isOfType(valueOne, String) && isOfType(valueTwo, Bool) && matcher == null)
 //		{
 //			assertThatBool(valueOne, valueTwo, info);
 //		}
-//		else if (Std.is(valueOne, Bool) && valueTwo == null && matcher == null)
+//		else if (isOfType(valueOne, Bool) && valueTwo == null && matcher == null)
 //		{
 //			assertThatBool("", valueOne, info);
 //		}

--- a/src/org/hamcrest/collection/IsArray.hx
+++ b/src/org/hamcrest/collection/IsArray.hx
@@ -10,6 +10,12 @@ import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeMatcher;
 import org.hamcrest.Exception;
 
+#if (haxe_ver >= 4.2)
+import Std.isOfType;
+#else
+import Std.is as isOfType;
+#end
+
 /**
  * Matcher for array whose elements satisfy a sequence of matchers.
  * The array size must equal the number of element matchers.
@@ -38,7 +44,7 @@ class IsArray<T> extends TypeSafeMatcher<Array<T>>
 	
 	override function isExpectedType(value:Dynamic):Bool
 	{
-		return Std.is(value, Array);
+		return isOfType(value, Array);
 	}
 
 	override function describeMismatchSafely(actual:Array<T>, mismatchDescription:Description):Void

--- a/src/org/hamcrest/collection/IsHashContaining.hx
+++ b/src/org/hamcrest/collection/IsHashContaining.hx
@@ -11,6 +11,11 @@ import org.hamcrest.TypeSafeMatcher;
 import org.hamcrest.core.IsAnything;
 import org.hamcrest.core.IsEqual;
 
+#if (haxe_ver >= 4.2)
+import Std.isOfType;
+#else
+import Std.is as isOfType;
+#end
 
 class IsHashContaining<K, V> extends TypeSafeMatcher<Map<K, V>>
 {
@@ -34,7 +39,7 @@ class IsHashContaining<K, V> extends TypeSafeMatcher<Map<K, V>>
     
     override function isExpectedType(value:Dynamic):Bool
     {
-    	return Std.is(value, IMap);
+    	return isOfType(value, IMap);
     }
 
     override function describeMismatchSafely(hash:Map<K, V>, mismatchDescription:Description)
@@ -90,7 +95,7 @@ class IsHashContaining<K, V> extends TypeSafeMatcher<Map<K, V>>
     
     static function getMatcher<T>(value:Dynamic):Matcher<T>
     {    	
-    	return Std.is(value, Matcher) ? value : IsEqual.equalTo(value);
+    	return isOfType(value, Matcher) ? value : IsEqual.equalTo(value);
     }
 }
 

--- a/src/org/hamcrest/collection/IsIterableWithSize.hx
+++ b/src/org/hamcrest/collection/IsIterableWithSize.hx
@@ -10,6 +10,12 @@ import org.hamcrest.Exception;
 import org.hamcrest.core.IsEqual;
 import org.hamcrest.internal.TypeIdentifier;
 
+#if (haxe_ver >= 4.2)
+import Std.isOfType;
+#else
+import Std.is as isOfType;
+#end
+
 class IsIterableWithSize<E> extends FeatureMatcher<Iterable<E>, Int>
 {
 	static var FEATURE_NAME = "iterable size";
@@ -22,7 +28,7 @@ class IsIterableWithSize<E> extends FeatureMatcher<Iterable<E>, Int>
 
     override function featureValueOf(actual:Iterable<E>):Int
     {
-        if (Std.is(actual, Array))
+        if (isOfType(actual, Array))
         {
             return cast(actual, Array<Dynamic>).length;
         }
@@ -50,7 +56,7 @@ class IsIterableWithSize<E> extends FeatureMatcher<Iterable<E>, Int>
 	{
 		featureName = FEATURE_NAME;
 		featureDescription = FEATURE_DESCRIPTION;
-		if (Std.is(actual, Array))
+		if (isOfType(actual, Array))
 		{
 			featureName = featureName.split("iterable").join("array");
 			featureDescription =featureDescription.split("iterable").join("array");
@@ -67,9 +73,9 @@ class IsIterableWithSize<E> extends FeatureMatcher<Iterable<E>, Int>
      */
     public static function hasSize<T>(value:Dynamic):Matcher<Iterable<T>>
     {
-    	if (Std.is(value, Matcher))
+    	if (isOfType(value, Matcher))
     		return new IsIterableWithSize<T>(value);
-    	else if (Std.is(value, Int))
+    	else if (isOfType(value, Int))
     		return hasSize(IsEqual.equalTo(value));
     	
     	throw new IllegalArgumentException();

--- a/src/org/hamcrest/core/AllOf.hx
+++ b/src/org/hamcrest/core/AllOf.hx
@@ -9,6 +9,11 @@ import org.hamcrest.DiagnosingMatcher;
 import org.hamcrest.Matcher;
 import org.hamcrest.Exception;
 
+#if (haxe_ver >= 4.2)
+import Std.isOfType;
+#else
+import Std.is as isOfType;
+#end
 
 /**
  * Calculates the logical conjunction of multiple matchers. Evaluation is shortcut, so
@@ -55,11 +60,11 @@ class AllOf<T> extends DiagnosingMatcher<T>
     							 ?tenth:Matcher<T>):AllOf<T>
     {
     	var matchers:Array<Matcher<T>>;
-    	if (Std.is(first, Array))
+    	if (isOfType(first, Array))
     	{
     		matchers = cast first;
     	}
-    	else if (Std.is(first, Matcher))
+    	else if (isOfType(first, Matcher))
     	{
     		matchers = [];
     		matchers.push(cast first);

--- a/src/org/hamcrest/core/AnyOf.hx
+++ b/src/org/hamcrest/core/AnyOf.hx
@@ -9,6 +9,12 @@ import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.Exception;
 
+#if (haxe_ver >= 4.2)
+import Std.isOfType;
+#else
+import Std.is as isOfType;
+#end
+
 /**
  * Calculates the logical disjunction of multiple matchers. Evaluation is shortcut, so
  * subsequent matchers are not called if an earlier matcher returns <code>true</code>.
@@ -38,11 +44,11 @@ class AnyOf<T> extends ShortcutCombination<T>
     {
     
     	var matchers:Array<Matcher<T>>;
-    	if (Std.is(first, Array))
+    	if (isOfType(first, Array))
     	{
     		matchers = cast first;
     	}
-    	else if (Std.is(first, Matcher))
+    	else if (isOfType(first, Matcher))
     	{
     		matchers = [];
     		matchers.push(cast first);

--- a/src/org/hamcrest/core/Is.hx
+++ b/src/org/hamcrest/core/Is.hx
@@ -9,6 +9,12 @@ import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.Exception;
 
+#if (haxe_ver >= 4.2)
+import Std.isOfType;
+#else
+import Std.is as isOfType;
+#end
+
 /**
  * Decorates another Matcher, retaining the behavior but allowing tests
  * to be slightly more expressive.
@@ -43,10 +49,10 @@ class Is<T> extends BaseMatcher<T>
 
 	public static function is<T>(value:Dynamic):Matcher<T>
 	{
-		if (Std.is(value, Matcher))
+		if (isOfType(value, Matcher))
 			return new Is<T>(value);
 
-		if (Std.is(value, Class))
+		if (isOfType(value, Class))
 			return isA(value);
 
 		return is(IsEqual.equalTo(value));

--- a/src/org/hamcrest/core/IsCollectionContaining.hx
+++ b/src/org/hamcrest/core/IsCollectionContaining.hx
@@ -10,6 +10,12 @@ import org.hamcrest.TypeSafeDiagnosingMatcher;
 import org.hamcrest.Exception;
 import org.hamcrest.internal.TypeIdentifier;
 
+#if (haxe_ver >= 4.2)
+import Std.isOfType;
+#else
+import Std.is as isOfType;
+#end
+
 class IsCollectionContaining<T> extends TypeSafeDiagnosingMatcher<Iterable<T>> 
 {
     var elementMatcher:Matcher<T>;
@@ -53,7 +59,7 @@ class IsCollectionContaining<T> extends TypeSafeDiagnosingMatcher<Iterable<T>>
     
     public static function hasItem<T>(value:Dynamic):Matcher<Iterable<T>>
     {
-    	if (Std.is(value, Matcher))
+    	if (isOfType(value, Matcher))
     		return new IsCollectionContaining<T>(value);
     	
     	return new IsCollectionContaining<T>(IsEqual.equalTo(value));
@@ -67,7 +73,7 @@ class IsCollectionContaining<T> extends TypeSafeDiagnosingMatcher<Iterable<T>>
     		
     		if (values.length > 0)
 	    	{
-	    		if (Std.is(values[0], Matcher))
+	    		if (isOfType(values[0], Matcher))
 	    		{
 					
 				    for (elementMatcher in values)

--- a/src/org/hamcrest/core/IsEqual.hx
+++ b/src/org/hamcrest/core/IsEqual.hx
@@ -10,6 +10,11 @@ import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 
+#if (haxe_ver >= 4.2)
+import Std.isOfType;
+#else
+import Std.is as isOfType;
+#end
 
 /**
  * Is the value equal to another value, as tested by the
@@ -89,7 +94,7 @@ class IsEqual<T> extends BaseMatcher<T>
 
     static function isArray(value:Dynamic):Bool
     {
-        return Std.is(value, Array);
+        return isOfType(value, Array);
     }
 
     static function isEnum(value: Dynamic):Bool

--- a/src/org/hamcrest/core/IsInstanceOf.hx
+++ b/src/org/hamcrest/core/IsInstanceOf.hx
@@ -10,6 +10,12 @@ import org.hamcrest.Description;
 import org.hamcrest.DiagnosingMatcher;
 import org.hamcrest.Matcher;
 
+#if (haxe_ver >= 4.2)
+import Std.isOfType;
+#else
+import Std.is as isOfType;
+#end
+
 
 /**
  * Tests whether the value is an instance of a class.
@@ -39,7 +45,7 @@ class IsInstanceOf extends DiagnosingMatcher<Dynamic>
 			return false;
 		}
       
-		if (!Std.is(item, expectedClass))
+		if (!isOfType(item, expectedClass))
 		{
 			var type = Type.getClass(item);
 			var className = type != null ? Type.getClassName(type) : "Dynamic";

--- a/src/org/hamcrest/core/IsNot.hx
+++ b/src/org/hamcrest/core/IsNot.hx
@@ -10,6 +10,11 @@ import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 
+#if (haxe_ver >= 4.2)
+import Std.isOfType;
+#else
+import Std.is as isOfType;
+#end
 
 /**
  * Calculates the logical negation of a matcher.
@@ -42,7 +47,7 @@ class IsNot<T> extends BaseMatcher<T>
      */
     public static function not<T>(value:Dynamic):Matcher<T>
     {
-    	if (Std.is(value, Matcher))
+    	if (isOfType(value, Matcher))
     		return new IsNot<T>(value);
     	
     	return not(IsEqual.equalTo(value));

--- a/src/org/hamcrest/core/SubstringMatcher.hx
+++ b/src/org/hamcrest/core/SubstringMatcher.hx
@@ -8,6 +8,12 @@ import org.hamcrest.Description;
 import org.hamcrest.TypeSafeMatcher;
 import org.hamcrest.Exception;
 
+#if (haxe_ver >= 4.2)
+import Std.isOfType;
+#else
+import Std.is as isOfType;
+#end
+
 class SubstringMatcher extends TypeSafeMatcher<String>
 {
     var substring:String;
@@ -38,7 +44,7 @@ class SubstringMatcher extends TypeSafeMatcher<String>
     
     override function isExpectedType(value:Dynamic):Bool
     {
-    	return Std.is(value, String);    
+    	return isOfType(value, String);
     }
 
     function evalSubstringOf(string:String):Bool

--- a/src/org/hamcrest/internal/TypeIdentifier.hx
+++ b/src/org/hamcrest/internal/TypeIdentifier.hx
@@ -5,6 +5,13 @@
 package org.hamcrest.internal;
 
 import Type.ValueType;
+
+#if (haxe_ver >= 4.2)
+import Std.isOfType;
+#else
+import Std.is as isOfType;
+#end
+
 class TypeIdentifier
 {
 	private function new()
@@ -15,7 +22,7 @@ class TypeIdentifier
 		if (value == null)
 			return false;
 			
-		if (Std.is(value, Array))
+		if (isOfType(value, Array))
 			return true;
 
 		var field = Reflect.field(value, "iterator");
@@ -43,7 +50,7 @@ class TypeIdentifier
 	
 	public static function isComparablePrimitive(value:Dynamic):Bool
 	{
-		return (isNumber(value) || Std.is(value, String));
+		return (isNumber(value) || isOfType(value, String));
 	}
 	
 	public static function hasCompareToFunction(value:Dynamic):Bool
@@ -60,7 +67,7 @@ class TypeIdentifier
 		if (isComparablePrimitive(value))
 			return true;
 		
-		if (Std.is(value, Date)) // assumes we'll be comparing date.getTime()
+		if (isOfType(value, Date)) // assumes we'll be comparing date.getTime()
 			return true;
 		
 		if (hasCompareToFunction(value))

--- a/src/org/hamcrest/internal/VarArgMatchers.hx
+++ b/src/org/hamcrest/internal/VarArgMatchers.hx
@@ -9,6 +9,12 @@ import org.hamcrest.Exception;
 import org.hamcrest.core.IsEqual;
 import haxe.PosInfos;
 
+#if (haxe_ver >= 4.2)
+import Std.isOfType;
+#else
+import Std.is as isOfType;
+#end
+
 class VarArgMatchers
 {
     public static function newIterable<T>(type:Class<Matcher<Iterable<T>>>, 
@@ -44,7 +50,7 @@ class VarArgMatchers
 	                                 ?tenth:Dynamic):Array<Matcher<T>>
     {
     	var matchers:Array<Matcher<T>> = [];
-    	if (Std.is(first, Array))
+    	if (isOfType(first, Array))
     	{
     		var items:Array<Dynamic> = cast first;
 			for (item in items) matchers.push(getMatcher(item));
@@ -69,7 +75,7 @@ class VarArgMatchers
 
 	static function getMatcher<T>(item:Dynamic):Matcher<T>
 	{
-		if (Std.is(item, Matcher))
+		if (isOfType(item, Matcher))
 			return cast item;
 		else
 			return IsEqual.equalTo(item);

--- a/src/org/hamcrest/number/IsCloseTo.hx
+++ b/src/org/hamcrest/number/IsCloseTo.hx
@@ -8,6 +8,12 @@ import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeMatcher;
 
+#if (haxe_ver >= 4.2)
+import Std.isOfType;
+#else
+import Std.is as isOfType;
+#end
+
 
 /**
  * Is the value a number equal to a value within some range of
@@ -32,7 +38,7 @@ class IsCloseTo extends TypeSafeMatcher<Float>
 
     override function isExpectedType(value:Dynamic):Bool
     {
-    	return Std.is(value, Float);   
+    	return isOfType(value, Float);
     }
     
     override function describeMismatchSafely(item:Float, mismatchDescription:Description)

--- a/src/org/hamcrest/number/OrderingComparison.hx
+++ b/src/org/hamcrest/number/OrderingComparison.hx
@@ -6,6 +6,12 @@ import org.hamcrest.Matcher;
 import org.hamcrest.internal.TypeIdentifier;
 import org.hamcrest.Exception;
 
+#if (haxe_ver >= 4.2)
+import Std.isOfType;
+#else
+import Std.is as isOfType;
+#end
+
 class OrderingComparison extends TypeSafeMatcher<Dynamic>
 {
 	static var LESS_THAN:Int = -1;
@@ -50,7 +56,7 @@ class OrderingComparison extends TypeSafeMatcher<Dynamic>
 			{
 				value = Reflect.compare(actual, expected);
 			}
-			else if (TypeIdentifier.isNumber(actual) && Std.is(expected, Date))
+			else if (TypeIdentifier.isNumber(actual) && isOfType(expected, Date))
 			{
 				value = Reflect.compare(actual, cast(expected, Date).getTime());
 			}
@@ -65,13 +71,13 @@ class OrderingComparison extends TypeSafeMatcher<Dynamic>
 				throw new IllegalArgumentException("Expected value is not of a comparable type. [" + expected + "]");
 			}
 		}
-		else if (Std.is(actual, Date))
+		else if (isOfType(actual, Date))
 		{
 			if (TypeIdentifier.isNumber(expected))
 			{
 				value = Reflect.compare(cast(actual, Date).getTime(), expected);
 			}
-			else if (Std.is(expected, Date))
+			else if (isOfType(expected, Date))
 			{
 				value = Reflect.compare(cast(actual, Date).getTime(), cast(expected, Date).getTime());
 			}


### PR DESCRIPTION
This works with versions older than haxe 4.2 as well